### PR TITLE
Call apply correctly

### DIFF
--- a/src/e-smart-zoom-jquery.js
+++ b/src/e-smart-zoom-jquery.js
@@ -145,7 +145,7 @@
 		    	$(window).bind('resize.smartZoom', windowResizeEventHandler); // call "adjustToContainer" on resize
 
 		    if(settings.initCallback != null) // call callback function after plugin initialization
-		    	settings.initCallback.apply(this, targetElement);
+		    	settings.initCallback.apply(this, [targetElement]);
 	    },
 	   /**
 		  * zoom function used into the plugin and accessible via direct call (ex : $('#zoomImage').smartZoom('zoom', 0.2);)


### PR DESCRIPTION
When an initCallback is provided the apply call is not sending an array parameter as expected.

This commit ensures an array is provided when calling apply.

Note: I did not update the minified version as there were no instructions on how to do it.
