### PR TITLE
Fixing destroy method unbindings

### DIFF
--- a/src/e-smart-zoom-jquery.js
+++ b/src/e-smart-zoom-jquery.js
@@ -241,7 +241,7 @@
 	    	var containerDiv = smartData.containerDiv;
 	    	// remove all listenerns 
 	        targetElement.unbind('mousedown.smartZoom');
-	        targetElement.bind('touchstart.smartZoom');
+	        targetElement.unbind('touchstart.smartZoom');
 	    	containerDiv.unbind('mousewheel.smartZoom');
 	        containerDiv.unbind('dblclick.smartZoom');
 	    	containerDiv.unbind( 'mousewheel.smartZoom DOMMouseScroll.smartZoom');


### PR DESCRIPTION
Fixing destroy method unbindings as the current one bind instead of unbinding touchStart event.
