### PR TITLE
Avoids putting variable 'settings' as a global variable. 

### DIFF
--- a/src/e-smart-zoom-jquery.js
+++ b/src/e-smart-zoom-jquery.js
@@ -61,7 +61,7 @@
 	    		return; 
 	    		
 	    	// Create some defaults, extending them with any options that were provided
-			settings = $.extend( {
+			var settings = $.extend( {
 		      'top' : "0",
 		      'left' : "0",
 		      'width' : "100%",


### PR DESCRIPTION
'settings' is currently set in the global scope. It is now a regular local variable.
