### PR TITLE
Prevent default on drag only when zoomed

### DIFF
--- a/src/e-smart-zoom-jquery.js
+++ b/src/e-smart-zoom-jquery.js
@@ -377,8 +377,6 @@
      * @param {Object} e : touch event  
      */
     function touchStartHandler(e){
-    	e.preventDefault(); // prevent default browser drag
-    	
     	$(document).unbind('touchmove.smartZoom'); // unbind if we already listen touch events
 	    $(document).unbind('touchend.smartZoom');
     	
@@ -408,7 +406,7 @@
      */
     function touchMoveHandler(e){ 
 
- 		e.preventDefault(); // prevent default browser behaviour
+ 	preventDefaultOnDrag(e); // prevent default browser behaviour when the target is zoomed
 
     	var smartData = targetElement.data('smartZoomData');
     	
@@ -454,6 +452,22 @@
 			smartData.touch.lastTouchPositionArr[0] = currentP1; //update last touch position points for next function iteration 
 			smartData.touch.lastTouchPositionArr[1] = currentP2;
 		}
+    }
+    
+    /**
+     * Prevent default browser behaviour on drag into the target only when it is zoomed
+     * 
+     * @param {Event} e : the original touch event
+     */
+    function preventDefaultOnDrag(e) {
+    	var smartData = targetElement.data('smartZoomData');
+        var targetRect = getTargetRect(); // the current plugin target size
+        var originSize = smartData.originalSize; // original plugin target size
+        var currentScale = (targetRect.width / originSize.width); 
+        
+        if (currentScale !== 1) {
+            e.preventDefault();
+        }
     }
     
     /**


### PR DESCRIPTION
This changes allow the user to scroll the page on drag event on the target only when it is not zoomed. Otherwise, it prevents the default browser behaviour.
